### PR TITLE
Downgrade to .NET 7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-ARG VARIANT=8.0
+ARG VARIANT=7.0
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 ENV PATH $PATH:/home/vscode/.dotnet:/home/vscode/.dotnet/tools

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
   validate-dotnet:
     name: Validate .NET solution
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: mcr.microsoft.com/dotnet/sdk:7.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4     

--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -33,7 +33,7 @@ module appServiceSite '../core/web/app-service/site.bicep' = {
         'azd-service-name': serviceTag
       })
     runtimeName: 'dotnetcore' // ASP.NET
-    runtimeVersion: '8.0' // .NET 8 (LTS)
+    runtimeVersion: '7.0' // .NET 7 (LTS)
     enableSystemAssignedManagedIdentity: true // Create system-assigned managed identity
   }
 }
@@ -49,7 +49,7 @@ module appServiceConfig '../core/web/app-service/config.bicep' = {
     appSettings: {
       SCM_DO_BUILD_DURING_DEPLOYMENT: string(false)
       ENABLE_ORYX_BUILD: string(true)
-      WEBSITES_PORT: '8080'
+      WEBSITES_PORT: '80'
       AZURE_COSMOS_DB_NOSQL_ENDPOINT: databaseAccountEndpoint
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ When you are finished, you will have a fully functional web application deployed
 The following prerequisites are required to use this application. Please ensure that you have them all installed locally.
 
 - [Azure Developer CLI](https://aka.ms/azd-install)
-- [.NET SDK 8.0](https://dotnet.microsoft.com/download/dotnet/8.0) 
+- [.NET SDK 7.0](https://dotnet.microsoft.com/download/dotnet/7.0) 
 
 ### Quickstart
 
@@ -49,7 +49,7 @@ Here's a high level architecture diagram that illustrates these components. Noti
 %%{ init: { 'theme': 'base', 'themeVariables': { 'background': '#243A5E', 'primaryColor': '#50E6FF', 'primaryBorderColor': '#243A5E', 'tertiaryBorderColor': '#50E6FF', 'tertiaryColor': '#243A5E', 'fontFamily': 'Segoe UI', 'lineColor': '#FFFFFF', 'primaryTextColor': '#243A5E', 'tertiaryTextColor': '#FFFFFF' } }}%%
 flowchart TB
     subgraph app-service[Azure App Service]
-        app-framework([.NET 8 - Blazor])
+        app-framework([.NET 7 - Blazor])
     end
     subgraph cosmos-db[Azure Cosmos DB]
         subgraph database-cosmicworks[Database: cosmicworks]

--- a/src/web/Cosmos.Samples.NoSQL.Quickstart.Web.csproj
+++ b/src/web/Cosmos.Samples.NoSQL.Quickstart.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>65c85440-31fd-4394-ae83-614ffddbb71f</UserSecretsId>

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -1,12 +1,9 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER app
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
+EXPOSE 80
+EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["web/Cosmos.Samples.NoSQL.Quickstart.Web.csproj", "web/"]


### PR DESCRIPTION
Azure Cloud Shell only supports .NET 7 today. The application must be downgrade to .NET 7 until Azure Cloud Shell supports .NET 8.