### PR TITLE
Try and fix .NET 7 deployment issues

### DIFF
--- a/src/web/Cosmos.Samples.NoSQL.Quickstart.Web.csproj
+++ b/src/web/Cosmos.Samples.NoSQL.Quickstart.Web.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>65c85440-31fd-4394-ae83-614ffddbb71f</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.*" />


### PR DESCRIPTION
After downgrading to .NET 7, there are some odd issues with the template where it will return a `Cannot find the fallback endpoint specified by route values: { page: /_Host, area: }` exception.

This PR is an attempt to fix this issue.