### PR TITLE
Remove unused default container image

### DIFF
--- a/infra/app/web.bicep
+++ b/infra/app/web.bicep
@@ -60,7 +60,6 @@ module containerAppsApp '../core/host/container-apps/app.bicep' = {
     userAssignedManagedIdentityIds: [
       userAssignedManagedIdentity.resourceId
     ]
-    containerImage: 'ghcr.io/azure-samples/cosmos-db-nosql-dotnet-quickstart:main' // Pre-built container image and tag from GitHub
   }
 }
 


### PR DESCRIPTION
The project originally had a default container image that was used. This has been removed in favor of the Microsoft hello-world image.