### PR TITLE
Pin `Azure.Identity` to `1.12.1`

### DIFF
--- a/src/web/Microsoft.Samples.Cosmos.NoSQL.Quickstart.Web.csproj
+++ b/src/web/Microsoft.Samples.Cosmos.NoSQL.Quickstart.Web.csproj
@@ -6,7 +6,7 @@
     <UserSecretsId>f6167579-5a7c-405e-bdae-cf20a79d6b9d</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.*" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
   </ItemGroup>


### PR DESCRIPTION
The latest version of [Azure.Identity (1.13.0)](https://www.nuget.org/packages/Azure.Identity/1.13.0) has a bug where the token credential chain doesn't progress past the managed identity option.

This is a temporary workaround until this bug is resolved:

- [x] Azure/azure-sdk-for-net#45808

More reading about token credential chains: <https://learn.microsoft.com/dotnet/azure/sdk/authentication/credential-chains>